### PR TITLE
ci: npm publish workflow (release-triggered, next dist-tag)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish to npm
+
+# Publishes the package under the "next" dist-tag when a GitHub Release is
+# published (tag like v0.2.0). Also available via manual dispatch.
+#
+# Requires repository secret NPM_TOKEN: an npm automation token with publish
+# rights to the @spryker-sdk scope.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        required: true
+        default: 'next'
+
+permissions:
+  contents: read
+  id-token: write # enables npm provenance
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate (type-check, lint, test)
+        run: npm run validate
+
+      - name: Verify release tag matches package.json version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::Release tag '$TAG' does not match package.json version '$PKG_VERSION'. Bump the version (and config.server.version) before tagging."
+            exit 1
+          fi
+
+      - name: Resolve dist-tag
+        id: tag
+        run: echo "value=${{ github.event.inputs.dist_tag || 'next' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        # npm publish triggers the package's prepublishOnly (clean + build + test),
+        # so the published dist is always freshly built from source.
+        run: npm publish --tag "${{ steps.tag.outputs.value }}" --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
Adds a `Publish to npm` GitHub Actions workflow, separate from the CI gate.

## How it works
- **Trigger:** when a **GitHub Release is published** (tag like `v0.2.0`); also a manual **workflow_dispatch** (with a `dist_tag` input, default `next`).
- **Steps:** `npm ci` → `npm run validate` (type-check + lint + test) → verify the release tag matches `package.json` version → `npm publish --tag next --access public --provenance`.
- `npm publish` triggers the package's existing `prepublishOnly` (clean + build + test), so the published `dist/` is always freshly built.
- Adds `publishConfig.access: public` for the scoped package.

## Before this can publish (your side)
1. Create an npm **automation token** with publish rights to the `@spryker-sdk` scope and add it as the repo secret **`NPM_TOKEN`** (Settings → Secrets and variables → Actions).
2. Ensure the `@spryker-sdk` org exists on npm with you as a publisher.
3. To release: bump `version` in `package.json` (and `config.server.version`), merge, then publish a GitHub Release tagged `v<version>`.

## Notes
- Publishes under the **`next`** dist-tag, so users only get it with `npm install @spryker-sdk/spryker-mcp-server@next` — a deliberate fit for the repo's "demo preview" disclaimer. Switch to `latest` later by changing the `--tag`.
- Provenance needs `id-token: write` (already set) and a public package; drop `--provenance` if your npm plan doesn't support it.